### PR TITLE
Fix mismatched props

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ import MagicGrid from 'magic-grid-react'
 
 Supports all optinons in [Magic-Grid](https://github.com/e-oj/Magic-Grid#magicgridconfig)
 
-#### Default Props: 
+#### Default Props:
 
 | Prop        | Default   | Comment                    |
 |:------------|:----------|:---------------------------|
-| gap         | `32`      | _Gap between elements_     |
+| gutter      | `32`      | _Gap between elements_     |
 | maxCols     | `5`       | _Max number of colums_     |
 | useMin      | `false`   | _Use min width of columns_ |
 | animate     | `false`   | _Animate item positioning_ |

--- a/src/MagicGrid.tsx
+++ b/src/MagicGrid.tsx
@@ -121,7 +121,7 @@ class MagicGridComponent extends React.Component<MagicGridComponentProps> {
 
 // @ts-ignore
 MagicGridComponent.defaultProps = {
-  gap: 32,
+  gutter: 32,
   maxCols: 5,
   maxColWidth: 280,
   useMin: false,

--- a/src/MagicGrid.tsx
+++ b/src/MagicGrid.tsx
@@ -4,7 +4,7 @@ import ReactResizeDetector from 'react-resize-detector'
 
 class RevokableMagicGrid extends MagicGrid {
   revoke() {}
-  
+
   listen() {
     if (this.ready()) {
       let revokeTimeout: any
@@ -40,7 +40,7 @@ export interface MagicGridComponentProps extends MagicGridProps {
   children?: React.ReactNode
 }
 
-class MagicGridComponent extends React.Component<MagicGridComponentProps> {  
+class MagicGridComponent extends React.Component<MagicGridComponentProps> {
   private gridInstance?: RevokableMagicGrid
   private wrapperRef: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -59,7 +59,7 @@ class MagicGridComponent extends React.Component<MagicGridComponentProps> {
 
   private positionItems = () => {
     console.log('gonna reposition')
-    
+
     if (this.gridInstance) {
       this.gridInstance.positionItems()
     }
@@ -76,7 +76,7 @@ class MagicGridComponent extends React.Component<MagicGridComponentProps> {
   private recreateInstance() {
     if (this.wrapperRef.current) {
       this.revokeInstance()
-      
+
       const {children, ...config} = {
         container: this.wrapperRef.current,
         items: (!this.props.static && this.props.children) ? ([] as React.ReactNode[]).concat(this.props.children).length : undefined,
@@ -125,7 +125,7 @@ MagicGridComponent.defaultProps = {
   maxCols: 5,
   maxColWidth: 280,
   useMin: false,
-  animate: true
+  animate: false
 }
 
 export * from 'magic-grid'


### PR DESCRIPTION
- `gap` renamed to `gutter` in README to reflect magic-grid name
- `animate` set to false to reflect the magic-grid default
- cleans up empty whitespace